### PR TITLE
feat: scaffold video api

### DIFF
--- a/v0/api/app.js
+++ b/v0/api/app.js
@@ -1,4 +1,17 @@
 import express from 'express';
+import cors from 'cors';
+
+import videoRoutes from './routes/video.js';
+import { authMiddleware } from './utils/auth.js';
+import { logger } from './utils/logger.js';
+
 const app = express();
+
+app.use(cors());
 app.use(express.json());
+app.use(logger);
+app.use(authMiddleware);
+
+app.use('/video', videoRoutes);
+
 export default app;

--- a/v0/api/package.json
+++ b/v0/api/package.json
@@ -5,11 +5,15 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3"
   }
 }

--- a/v0/api/routes/video.js
+++ b/v0/api/routes/video.js
@@ -1,1 +1,43 @@
-// Placeholder for /video routes
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+import { generateVideo } from '../services/videoGenerator.js';
+
+const router = Router();
+
+const topics = ['Custom', 'History', 'Science', 'Art'];
+const themes = ['Hormozi_1', 'Beast', 'Tracy', 'Noah', 'Karl', 'Luke'];
+const voices = ['Charlie', 'George', 'Callum', 'Sarah', 'Laura', 'Charlotte'];
+const styles = ['cinematic', 'anime', 'photographic', 'pixel art', 'watercolor', 'neon punk', 'slideshow'];
+const music = ['default', 'ambient', 'dramatic'];
+
+router.post('/generate', async (req, res) => {
+  try {
+    const result = await generateVideo(req.body || {});
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to generate video' });
+  }
+});
+
+router.get('/topics', (_req, res) => res.json(topics));
+router.get('/themes', (_req, res) => res.json(themes));
+router.get('/voices', (_req, res) => res.json(voices));
+router.get('/styles', (_req, res) => res.json(styles));
+router.get('/background-music', (_req, res) => res.json(music));
+
+router.get('/url', (req, res) => {
+  const { id } = req.query;
+  const outPath = path.resolve('..', 'samples', 'job_output.json');
+  if (id && fs.existsSync(outPath)) {
+    const data = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+    if (data.vid === id) {
+      return res.json(data);
+    }
+  }
+  return res.json({ vid: id, status: 'processing' });
+});
+
+export default router;

--- a/v0/api/server.js
+++ b/v0/api/server.js
@@ -1,2 +1,11 @@
 // Server entry
-import './app.js';
+import dotenv from 'dotenv';
+import app from './app.js';
+
+dotenv.config();
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/v0/api/services/configRouter.js
+++ b/v0/api/services/configRouter.js
@@ -1,1 +1,3 @@
-// Maps style to provider based on config
+export function routeConfig(style = '') {
+  return style === 'slideshow' ? 'slideshow' : 'ai_generated';
+}

--- a/v0/api/services/scriptGenerator.js
+++ b/v0/api/services/scriptGenerator.js
@@ -1,1 +1,3 @@
-// Placeholder for LLM-driven script generation
+export async function generateScript(promptOrTopic) {
+  return `Generated script for: ${promptOrTopic}`;
+}

--- a/v0/api/services/videoGenerator.js
+++ b/v0/api/services/videoGenerator.js
@@ -1,17 +1,28 @@
 import fs from 'fs';
 import path from 'path';
 
+import { generateScript } from './scriptGenerator.js';
+import { synthesizeVoice } from './voiceGenerator.js';
+import { routeConfig } from './configRouter.js';
+
 export async function generateVideo(config) {
   const vid = `mock_vid_${Date.now()}`;
+  const script = await generateScript(config.prompt || config.topic);
+  const voice_file = await synthesizeVoice(script, config.voice);
+  const mode = routeConfig(config.style);
+
   const output = {
     vid,
-    script: "Generated script for: " + (config.prompt || config.topic),
-    voice_file: `${vid}_voice.mp3`,
+    script,
+    voice_file,
     video_file: `${vid}_video.mp4`,
-    status: "complete",
-    url: `https://mockcdn.ai/videos/${vid}.mp4`
+    status: 'complete',
+    url: `https://mockcdn.ai/videos/${vid}.mp4`,
+    mode,
   };
-  const outPath = path.resolve('samples', 'job_output.json');
+
+  const outPath = path.resolve('..', 'samples', 'job_output.json');
   fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
-  return { vid, status: "processing", message: "Video generation job created." };
+
+  return { vid, status: 'processing', message: 'Video generation job created.' };
 }

--- a/v0/api/services/voiceGenerator.js
+++ b/v0/api/services/voiceGenerator.js
@@ -1,1 +1,3 @@
-// Placeholder for TTS synthesis
+export async function synthesizeVoice(_script, voice) {
+  return `${voice || 'default'}_voice.mp3`;
+}

--- a/v0/api/test/video.test.js
+++ b/v0/api/test/video.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import request from 'supertest';
+import app from '../app.js';
+
+const API_KEY = 'testkey';
+
+test('GET /video/topics returns list of topics', async () => {
+  const res = await request(app)
+    .get('/video/topics')
+    .set('X-API-KEY', API_KEY);
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(res.body, ['Custom', 'History', 'Science', 'Art']);
+});
+
+test('POST /video/generate returns job status', async () => {
+  const res = await request(app)
+    .post('/video/generate')
+    .set('X-API-KEY', API_KEY)
+    .send({ topic: 'History', voice: 'Charlie', style: 'cinematic' });
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.status, 'processing');
+  assert.ok(res.body.vid);
+});
+

--- a/v0/api/utils/auth.js
+++ b/v0/api/utils/auth.js
@@ -1,1 +1,8 @@
-// Mock API key validation middleware
+export function authMiddleware(req, res, next) {
+  const apiKey = req.header('X-API-KEY');
+  const expected = process.env.API_KEY || 'testkey';
+  if (!apiKey || apiKey !== expected) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}

--- a/v0/api/utils/logger.js
+++ b/v0/api/utils/logger.js
@@ -1,1 +1,4 @@
-// Basic logging helper
+export function logger(req, _res, next) {
+  console.log(`${new Date().toISOString()} ${req.method} ${req.originalUrl}`);
+  next();
+}


### PR DESCRIPTION
## Summary
- add express app with auth, logging and video routes
- implement mock video generator, script/voice helpers and config router
- expose endpoints for metadata and job status
- configure node test runner and add video route tests

## Testing
- `npm --prefix v0/api test`


------
https://chatgpt.com/codex/tasks/task_e_688ea491272883208f2ed870e9281a73